### PR TITLE
fix problem while parsing Packages:cleartext in supplementary creds

### DIFF
--- a/ntds/dsobjects.py
+++ b/ntds/dsobjects.py
@@ -552,7 +552,7 @@ class dsSupplCredentials:
         elif Name == u"Packages":
             self.Packages = unhexlify(text[offset:offset+ValueLength]).decode('utf-16').split("\x00")
         elif Name == u"Primary:CLEARTEXT":
-            self.Password = text[offset:offset+ValueLength])
+            self.Password = text[offset:offset+ValueLength]
         else:
             print Name
         return offset + ValueLength


### PR DESCRIPTION
It looks like there is a little problem while retrieving the <b>Supplementary Credentials</b>.
in the `ntdsxtract/ntds/dsobjects.py` file

``` python
def ParseUserProperty(self, text, offset):
        [...]
        elif Name == u"Primary:CLEARTEXT":
            self.Password = unhexlify(text[offset:offset+ValueLength]).decode('utf-16')
        else:
            print Name
        return offset + ValueLength
```

I get an encoding error because the value seems to already be an ascii _String_

```
Supplemental credentials:
  Kerberos newer keys
    salt: I[...]t
    Credentials
      18 fa[...]53
      17 cb[...]a2
      3 20[...]70
  Kerberos keys
    salt: I[...]t
    Credentials
      3 20[...]70
    OldCredentials
      3 c1[...]10
      1 c1[...]10
  WDigest hashes
    903e44489957c3a3ca489b86be83d12f
    [...]
    85f363474700b4dfa0ace59bdbc6ad98
  Packages
    Kerberos-Newer-Keys
    Kerberos
    WDigest
    CLEARTEXT
 [!] Error! 'ascii' codec can't encode characters in position 0-15: ordinal not in range(128)
```

which turns to be coming from there :

```
  File "/opt/ntdsxtract/dsusers.py", line 446, in <module>
    processUser(user)
  File "/opt/ntdsxtract/dsusers.py", line 178, in processUser
    creds.Print("  ")
  File "/opt/ntdsxtract/ntds/dsobjects.py", line 506, in Print
    print "{0}Password: {1}".format(indent, self.Password)

```

I personnaly resolved that bug by applying this modification in `ntdsxtract/ntds/dsobjects.py`:

``` python
def ParseUserProperty(self, text, offset):
        [...]
        elif Name == u"Primary:CLEARTEXT":
            self.Password = text[offset:offset+ValueLength])
        else:
            print Name
        return offset + ValueLength
```

As I just jumped into your code, I might not have a clean step back on what's really happening, so I let you consider if it is a viable fix.

Take care ;)
