### PR TITLE
Faulty debug call + 8 char string blocks

### DIFF
--- a/ntds/__init__.py
+++ b/ntds/__init__.py
@@ -28,7 +28,7 @@ for arg in sys.argv:
         debug = True
 
 def simple_exception(type, value, traceback):
-    sys.stderr.write("[!] Error!", value, "\n")
+    sys.stderr.write("[!] Error!" + str(value) + "\n")
     sys.exit(1)
 
 if debug == False:

--- a/ntds/dsencryption.py
+++ b/ntds/dsencryption.py
@@ -64,5 +64,5 @@ def dsDecryptSingleHash(rid, enc_hash):
     (des_k1,des_k2) = sid_to_key(rid)
     d1 = DES.new(des_k1, DES.MODE_ECB)
     d2 = DES.new(des_k2, DES.MODE_ECB)
-    hash = d1.decrypt(enc_hash[:8]) + d2.decrypt(enc_hash[8:])
-    return hash
+	hash = d1.decrypt(enc_hash[:8]) + d2.decrypt(enc_hash[8:16])
+	return hash[:16]


### PR DESCRIPTION
1. Fixed faulty call to sys.stderr.write
2. Fixed handling of strings in 8 char blocks.